### PR TITLE
flutter sdk新版本移除了AppLifecycleState.suspending方法

### DIFF
--- a/lib/src/lifecycle_state.dart
+++ b/lib/src/lifecycle_state.dart
@@ -54,8 +54,6 @@ abstract class LifecycleState<T extends StatefulWidget> extends State<T>
           onPause();
         }
         break;
-      case AppLifecycleState.suspending:
-        break;
       default:
         break;
     }


### PR DESCRIPTION
修复因新版移除AppLifecycleState.suspending方法而引起的bug